### PR TITLE
Optional branch support

### DIFF
--- a/src/coverage.ts
+++ b/src/coverage.ts
@@ -64,7 +64,7 @@ type CoverageFileLine = number | null;
 
 interface Coverage {
   lines: CoverageFileLine[];
-  branches: BranchData;
+  branches?: BranchData;
 }
 
 export enum LineCoverageStatus {
@@ -188,6 +188,10 @@ export class SourceFile {
 
   _branchesFromCoverage(coverage: Coverage): Branch[] {
     const branches: Branch[] = [];
+    if (!coverage.branches) {
+      return branches;
+    }
+
     const iterator = Object.entries(coverage.branches);
 
     for (const [condition, coverageBranches] of iterator) {
@@ -300,10 +304,13 @@ export class ResultMerger {
   }
 
   static mergeBranches(
-    coverageA: BranchData,
-    coverageB: BranchData
+    coverageA?: BranchData,
+    coverageB?: BranchData
   ): BranchData {
     let merged = { ...coverageA };
+    if (!coverageB) {
+      return merged;
+    }
 
     for (const [condition, branchesInsideB] of Object.entries(coverageB)) {
       if (!merged[condition]) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -416,7 +416,6 @@ function applyCodeCoverage(editor: vscode.TextEditor | undefined) {
     coverageOptions === "showUncoveredCodeOnly" ||
     coverageOptions === "showBothCoveredAndUncoveredCode"
   ) {
-    console.log(uncoveredBranchesDecorations);
     if (decorators.type === "gutter") {
       editor.setDecorations(decorators.uncoveredGutter, uncoveredDecorations);
       editor.setDecorations(


### PR DESCRIPTION
While I have branch support as a listed feature on the README, it wasn't intended to be required for the coverage highlighting to be applied. I realize now I have it as a required property in the `Coverage` interface. After digging in to a report about coverage not being applied in #4, I inspected the coverage file and noticed no branches in the JSON. I was able to reproduce the lack of coverage when the `branches` key was not present in a file across all suites reported.

Fixes #4 