### PR TITLE
Add simplecov.coverageDirectory config property to allow coverage directory to be configured

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,12 @@
           "description": "Use these options to control whether only covered or only uncovered code or both should be highlighted after generating a coverage report.",
           "scope": "resource"
         },
+        "simplecov.coverageDirectory": {
+          "type": "string",
+          "default": "coverage",
+          "description": "The path to the coverage directory. This is relative to the workspace root.",
+          "scope": "resource"
+        },
         "simplecov.coverageDecorator": {
           "type": "object",
           "properties": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -83,8 +83,9 @@ export function deactivate() {
 export function addWorkspaceFileSystemWatchers(
   context: vscode.ExtensionContext
 ) {
+  const coverageDirectory = getConfig().get("coverageDirectory") as string;
   const jsonWatcher =
-    vscode.workspace.createFileSystemWatcher("**/coverage/*.json");
+    vscode.workspace.createFileSystemWatcher(`**/${coverageDirectory}/*.json`);
 
   jsonWatcher.onDidChange((uri) => {
     outputChannel.appendLine(
@@ -434,6 +435,7 @@ function applyCodeCoverage(editor: vscode.TextEditor | undefined) {
 }
 
 function parseCoverageRanges() {
+  const coverageDirectory = getConfig().get("coverageDirectory") as string;
   outputChannel.appendLine(`Parsing coverage ranges`);
 
   coverageFiles = new Map<string, SourceFile>();
@@ -446,8 +448,8 @@ function parseCoverageRanges() {
     const workspaceFolder = workspaceFolders[0];
 
     const possiblePaths = [
-      path.join(workspaceFolder.uri.fsPath, "coverage", "coverage.json"),
-      path.join(workspaceFolder.uri.fsPath, "coverage", ".resultset.json"),
+      path.join(workspaceFolder.uri.fsPath, coverageDirectory, "coverage.json"),
+      path.join(workspaceFolder.uri.fsPath, coverageDirectory, ".resultset.json"),
     ];
 
     const coverageJsonPath = possiblePaths.find(fs.existsSync);


### PR DESCRIPTION
Add new config property that defaults to existing hardcoded 'coverage' value. Fixes #6.

I've tested this by manually building and installing the extension with `vsce package` and this appears to work for both the default value (if I move my coverage folder to `coverage/`), and custom values (if I configure `simplecov.coverageDirectory` to `.coverage` and move my coverage folder there).

This is my first time touching a VSCode extension codebase, please let me know if I've done anything silly 🙏 