### PR TITLE
Don't present information message when no coverage file found

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -462,9 +462,6 @@ function parseCoverageRanges() {
       outputChannel.appendLine(
         `No coverage file found in ${possiblePaths.join(", ")}`
       );
-      vscode.window.showInformationMessage(
-        `No coverage file found at ${possiblePaths.join(" or ")}`
-      );
       return;
     }
 


### PR DESCRIPTION
Currently, anytime you open a workspace that doesn't have a coverage file it'll present an information message in the bottom right of the editor:

> No coverage file found at …

It's excessively noisy in practice and the output channel logging is sufficient enough for debugging purposes.