### PR TITLE
Add extension commands to toggle, apply, and remove coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ The coverage is also displayed as a percentage in the editor's status bar:
   - `uncoveredBranchHighlightColor`: The highlight color to use for highlighting uncovered branches.
   - `uncoveredBranchGutterStyle`: The style to use for the gutter indicator for uncovered branches.
 
+## Commands
+
+- `simplecov.coverage.toggle`: Toggle the display of code coverage.
+- `simplecov.coverage.apply`: Apply the coverage to the currently active file.
+- `simplecov.coverage.remove`: Remove the coverage from the currently active file.
 
 ## Requirements
 

--- a/package.json
+++ b/package.json
@@ -138,7 +138,21 @@
           "scope": "resource"
         }
       }
-    }
+    },
+    "commands": [
+      {
+        "command": "simplecov.coverage.toggle",
+        "title": "SimpleCov: Toggle Coverage"
+      },
+      {
+        "command": "simplecov.coverage.apply",
+        "title": "SimpleCov: Apply Coverage"
+      },
+      {
+        "command": "simplecov.coverage.remove",
+        "title": "SimpleCov: Remove Coverage"
+      }
+    ]
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -68,11 +68,49 @@ export function activate(context: vscode.ExtensionContext) {
   initCoverageDecorators(context);
 
   addWorkspaceFileSystemWatchers(context);
+  addExtensionCommandListeners(context);
   addOnDidChangeConfigListeners(context);
   addOnChangeActiveTextEditorListeners(context);
   addOnSaveTextDocumentListeners(context);
 
   console.debug("simplecov extension activated");
+}
+
+function addExtensionCommandListeners(context: vscode.ExtensionContext) {
+  let toggleCoverageCommand = vscode.commands.registerCommand(
+    "simplecov.coverage.toggle",
+    toggleCoverage
+  );
+
+  let applyCoverageCommand = vscode.commands.registerCommand(
+    "simplecov.coverage.apply",
+    applyCoverage
+  );
+
+  let removeCoverageCommand = vscode.commands.registerCommand(
+    "simplecov.coverage.remove",
+    clearCoverage
+  );
+
+  context.subscriptions.push(toggleCoverageCommand);
+  context.subscriptions.push(applyCoverageCommand);
+  context.subscriptions.push(removeCoverageCommand);
+}
+
+function toggleCoverage() {
+  if (isCoverageApplied) {
+    console.debug(`toggleCoverage: removing coverage`);
+    clearCoverage();
+  } else {
+    console.debug(`toggleCoverage: applying coverage`);
+    applyCoverage();
+  }
+}
+
+function applyCoverage() {
+  console.debug(`applyCoverage: applying coverage`);
+  reloadCoverage();
+  vscode.window.visibleTextEditors.forEach(applyCodeCoverage);
 }
 
 // This method is called when your extension is deactivated
@@ -305,7 +343,6 @@ function clearCoverage() {
 }
 
 function reloadCoverage() {
-  console.debug("clearCoverage");
   outputChannel.appendLine(`Reloading coverage`);
 
   clearCoverage();
@@ -339,6 +376,7 @@ function removeCodeCoverageOnFileSave(e: vscode.TextDocument) {
 
 function applyCodeCoverage(editor: vscode.TextEditor | undefined) {
   if (!editor) {
+    console.debug(`applyCodeCoverage: no active text editor`);
     return;
   }
 


### PR DESCRIPTION
This PR adds the following extension commands:

- `simplecov.coverage.toggle`: Toggle the display of code coverage.
- `simplecov.coverage.apply`: Apply the coverage to the currently active file.
- `simplecov.coverage.remove`: Remove the coverage from the currently active file.

These commands are not bound to any shortcuts by default and can be bound to any keybinding in your `keybindings.json` file.

Closes https://github.com/dewski/vscode-simplecov/issues/13